### PR TITLE
Add stats for workerpool metrics

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -390,10 +390,6 @@ func (p *WorkerPool) GetWorkerCount() int {
 	return int(p.workerCount.Load())
 }
 
-func (p *WorkerPool) GetWaitingQueueLength() int32 {
-	return atomic.LoadInt32(&p.waiting)
-}
-
 // GetStatsAndReset returns the number of executions taken place from
 // last call. Ideally, it can be used to calculate rate of processing.
 func (p *WorkerPool) GetStatsAndReset() uint64 {


### PR DESCRIPTION
This PR adds few stats in worker pool to gather metrics. 

1. Total number of workers running at any time / total requests being processed at any time. 
2. Total number of requests processed per unit time (or any time range < 1hr). 

Another important metric is total requests in a queue is already present. 